### PR TITLE
feat: hierarchical RoleSessionName resolution when assuming role

### DIFF
--- a/pkg/cfaws/assumer_aws_credential_process.go
+++ b/pkg/cfaws/assumer_aws_credential_process.go
@@ -66,11 +66,7 @@ func (cpa *CredentialProcessAssumer) AssumeTerminal(ctx context.Context, c *Prof
 			return aws.Credentials{}, err
 		}
 		stsp := stscreds.NewAssumeRoleProvider(sts.New(sts.Options{Credentials: aws.NewCredentialsCache(&CredProv{creds}), Region: region}), c.AWSConfig.RoleARN, func(aro *stscreds.AssumeRoleOptions) {
-			if c.AWSConfig.RoleSessionName != "" {
-				aro.RoleSessionName = c.AWSConfig.RoleSessionName
-			} else {
-				aro.RoleSessionName = sessionName()
-			}
+			aro.RoleSessionName = getRoleSessionNameFromProfile(c)
 			if c.AWSConfig.MFASerial != "" {
 				aro.SerialNumber = &c.AWSConfig.MFASerial
 				aro.TokenProvider = MfaTokenProvider

--- a/pkg/cfaws/assumer_aws_iam.go
+++ b/pkg/cfaws/assumer_aws_iam.go
@@ -120,11 +120,8 @@ func (aia *AwsIamAssumer) AssumeTerminal(ctx context.Context, c *Profile, config
 					aro.SerialNumber = aws.String(c.AWSConfig.MFASerial)
 				}
 			}
-			if c.AWSConfig.RoleSessionName != "" {
-				aro.RoleSessionName = c.AWSConfig.RoleSessionName
-			} else {
-				aro.RoleSessionName = sessionName()
-			}
+
+			aro.RoleSessionName = getRoleSessionNameFromProfile(c)
 		}))
 
 		cfg, err := config.LoadDefaultConfig(ctx, opts...)

--- a/pkg/cfaws/assumer_aws_sso.go
+++ b/pkg/cfaws/assumer_aws_sso.go
@@ -112,11 +112,7 @@ func (c *Profile) SSOLoginWithToken(ctx context.Context, cfg *aws.Config, access
 			stsClient := sts.New(sts.Options{Credentials: aws.NewCredentialsCache(credProvider), Region: region})
 			stsp := stscreds.NewAssumeRoleProvider(stsClient, p.AWSConfig.RoleARN, func(aro *stscreds.AssumeRoleOptions) {
 				// all configuration goes in here for this profile
-				if p.AWSConfig.RoleSessionName != "" {
-					aro.RoleSessionName = p.AWSConfig.RoleSessionName
-				} else {
-					aro.RoleSessionName = sessionName()
-				}
+				aro.RoleSessionName = getRoleSessionNameFromProfile(p)
 				if p.AWSConfig.MFASerial != "" {
 					aro.SerialNumber = &p.AWSConfig.MFASerial
 					aro.TokenProvider = MfaTokenProvider

--- a/pkg/cfaws/session_name.go
+++ b/pkg/cfaws/session_name.go
@@ -9,3 +9,30 @@ func sessionName() string {
 	// using the acronym gntd to ensure the id is not longer than 32 chars
 	return "gntd-" + ksuid.New().String()
 }
+
+// findRoleSessionNameInParents recursively searches parent profiles for a RoleSessionName.
+func findRoleSessionNameInParents(profile *Profile) string {
+	if profile == nil {
+		return ""
+	}
+	if profile.AWSConfig.RoleSessionName != "" {
+		return profile.AWSConfig.RoleSessionName
+	}
+	if len(profile.Parents) > 0 {
+		return findRoleSessionNameInParents(profile.Parents[0])
+	}
+	return ""
+}
+
+// getRoleSessionNameFromProfile determines the RoleSessionName for a profile.
+// It checks the profile itself, then recursively checks parent profiles, and finally falls back to a generated session name.
+func getRoleSessionNameFromProfile(profile *Profile) string {
+	if profile.AWSConfig.RoleSessionName != "" {
+		return profile.AWSConfig.RoleSessionName
+	}
+	parentRoleSessionName := findRoleSessionNameInParents(profile)
+	if parentRoleSessionName != "" {
+		return parentRoleSessionName
+	}
+	return sessionName()
+}

--- a/pkg/cfaws/session_name_test.go
+++ b/pkg/cfaws/session_name_test.go
@@ -3,6 +3,7 @@ package cfaws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,4 +13,58 @@ func TestSessionName(t *testing.T) {
 	// getfederationtoken fails if name is longer than 32 characters long
 	name := sessionName()
 	assert.LessOrEqual(t, len(name), 32)
+}
+
+func TestFindRoleSessionNameInParents(t *testing.T) {
+	// Test case: No parent profiles
+	profile := &Profile{
+		AWSConfig: config.SharedConfig{RoleSessionName: ""},
+		Parents:   nil,
+	}
+	assert.Equal(t, "", findRoleSessionNameInParents(profile))
+
+	// Test case: Parent profile with RoleSessionName
+	parentProfile := &Profile{
+		AWSConfig: config.SharedConfig{RoleSessionName: "parent-session"},
+		Parents:   nil,
+	}
+	profile.Parents = []*Profile{parentProfile}
+	assert.Equal(t, "parent-session", findRoleSessionNameInParents(profile))
+
+	// Test case: Multiple parent profiles
+	grandParentProfile := &Profile{
+		AWSConfig: config.SharedConfig{RoleSessionName: "grandparent-session"},
+		Parents:   nil,
+	}
+	parentProfile.Parents = []*Profile{grandParentProfile}
+	assert.Equal(t, "parent-session", findRoleSessionNameInParents(profile))
+}
+
+func TestGetRoleSessionNameFromProfile(t *testing.T) {
+	// Test case: Profile with RoleSessionName
+	profile := &Profile{
+		AWSConfig: config.SharedConfig{RoleSessionName: "profile-session"},
+		Parents:   nil,
+	}
+	assert.Equal(t, "profile-session", getRoleSessionNameFromProfile(profile))
+
+	// Test case: Parent profile with RoleSessionName
+	parentProfile := &Profile{
+		AWSConfig: config.SharedConfig{RoleSessionName: "parent-session"},
+		Parents:   nil,
+	}
+	profile = &Profile{
+		AWSConfig: config.SharedConfig{RoleSessionName: ""},
+		Parents:   []*Profile{parentProfile},
+	}
+	assert.Equal(t, "parent-session", getRoleSessionNameFromProfile(profile))
+
+	// Test case: No RoleSessionName in profile or parents
+	profile = &Profile{
+		AWSConfig: config.SharedConfig{RoleSessionName: ""},
+		Parents:   nil,
+	}
+	name := getRoleSessionNameFromProfile(profile)
+	assert.NotEmpty(t, name)
+	assert.Contains(t, name, "gntd-")
 }


### PR DESCRIPTION
### Context

When assuming an AWS role, the AWSConfig `RoleSessionName` is set only by the attribute `role_session_name` in a profile config. When the `role_session_name` is not defined, the `RoleSessionName` is pseudo-random (`gntd-xxxxxx...xxx`) which is not helpful for tracability. 

Here is the current behavior for a profile that does not set the `role_session_name`, but has a `source_profile` with one defined:

```yaml
[default]
aws_account_id             = demo
region                     = ca-central-1
output                     = json
role_arn                   = arn:aws:iam::00000000000:role/GoogleLoginTest
web_identity_token_process = ~/.aws/gcloud-auth.sh
role_session_name          = frederic.perr@email.com
credential_process         = aws-vault export --format=json default

[profile abc]
role_arn       = arn:aws:iam::00000000000:role/ABCAccessRole
region         = ca-central-1
source_profile = default
```

```json
{
    "UserId": "XXXXXXXXXXXXXXXXXXX:gntd-2zeVDXqmmnIrdqFkA3c9Wk5Qt7I",
    "Account": "0000000000000",
    "Arn": "arn:aws:sts::0000000000000:assumed-role/OrganizationAccountAccessRole/gntd-2zeVDXqmmnIrdqFkA3c9Wk5Qt7I"
}
```

Here is the desired result achieved with this PR:
```json
{
    "UserId": "XXXXXXXXXXXXXXXXXXX:gntd-2zeVDXqmmnIrdqFkA3c9Wk5Qt7I",
    "Account": "0000000000000",
    "Arn": "arn:aws:sts::0000000000000:assumed-role/OrganizationAccountAccessRole/frederic.perr@email.com"
}
```

_The difference is in the Arn._

When having multiple profiles, it does not make sense to duplicate the `role_session_name` for every profile, but it does to inherit the `role_session_name` from the parent profile (`source_profile`). This is what `aws-vault` does, but `granted` does not.

### Changes made

This PR implements exactly that inheritence for the `role_session_name` where the a profile checks for its `role_session_name` first, then its parent, grandparent, and if none is found, then it falls back to the pseudo-random generation of the session name.