### PR TITLE
Add refresh option when assuming terminal IAM role

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -284,6 +284,7 @@ func AssumeCommand(c *cli.Context) error {
 		MFATokenCode: assumeFlags.String("mfa-token"),
 		Args:         assumeFlags.StringSlice("pass-through"),
 		DisableCache: assumeFlags.Bool("no-cache"),
+		Refresh:      assumeFlags.Bool("refresh"),
 	}
 
 	// attempt to get session duration from profile

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -55,6 +55,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "confirm", Aliases: []string{"y"}, Usage: "Skip confirmation prompts for access requests"},
 		&cli.BoolFlag{Name: "wait", Usage: "When using Granted with Common Fate the assume will halt while waiting for the access request to be approved."},
 		&cli.BoolFlag{Name: "no-cache", Usage: "Disables caching of session credentials and forces a refresh", EnvVars: []string{"GRANTED_NO_CACHE"}},
+		&cli.BoolFlag{Name: "refresh", Usage: "Forces Granted to refresh session credentials", EnvVars: []string{"GRANTED_REFRESH"}},
 		&cli.StringSliceFlag{Name: "browser-launch-template-arg", Usage: "Additional arguments to provide to the browser launch template command in key=value format, e.g. '--browser-launch-template-arg foo=bar"},
 		&cli.BoolFlag{Name: "skip-profile-registry-sync", Usage: "You can use this to skip the automated profile registry sync process."},
 		&cli.StringSliceFlag{Name: "attach", Usage: "Attach justifications to your request, such as a Jira ticket id or url `--attach=TP-123`"},

--- a/pkg/cfaws/profiles.go
+++ b/pkg/cfaws/profiles.go
@@ -27,6 +27,7 @@ type ConfigOpts struct {
 	ShouldRetryAssuming        *bool
 	MFATokenCode               string
 	DisableCache               bool
+	Refresh                    bool
 }
 
 type Profile struct {


### PR DESCRIPTION
Adds a force refresh flag to force Granted to renew credentials when assuming an IAM role, rather than re-using the current ones.

Useful when using IaC tools with long apply times where it is beneficial to restart your session before running the tool.