### PR TITLE
feat: add dynamic profile listing to fish shell autocomplete

### DIFF
--- a/pkg/granted/templates/fish_autocomplete_assume.tmpl
+++ b/pkg/granted/templates/fish_autocomplete_assume.tmpl
@@ -1,0 +1,18 @@
+# Fish completion for {{ .Program }} (assume)
+# Dynamically calls {{ .Program }}go --generate-bash-completion to list profiles and flags
+
+# Disable file completions by default for the assume command
+complete -c {{ .Program }} -f
+
+complete -c {{ .Program }} -a '(
+    set -l tokens (commandline -opc)
+    set -l current (commandline -ct)
+
+    # pass all tokens except the command name, plus --generate-bash-completion
+    set -l args
+    if test (count $tokens) -gt 1
+        set args $tokens[2..-1]
+    end
+
+    FORCE_NO_ALIAS=true {{ .Program }}go $args --generate-bash-completion 2>/dev/null
+)'

--- a/pkg/granted/templates/fish_autocomplete_granted.tmpl
+++ b/pkg/granted/templates/fish_autocomplete_granted.tmpl
@@ -1,0 +1,18 @@
+# Fish completion for {{ .Program }} (granted)
+# Dynamically calls {{ .Program }} --generate-bash-completion to list subcommands and flags
+
+# Disable file completions by default for the granted command
+complete -c {{ .Program }} -f
+
+complete -c {{ .Program }} -a '(
+    set -l tokens (commandline -opc)
+    set -l current (commandline -ct)
+
+    # pass all tokens except the command name, plus --generate-bash-completion
+    set -l args
+    if test (count $tokens) -gt 1
+        set args $tokens[2..-1]
+    end
+
+    _CLI_ZSH_AUTOCOMPLETE_HACK=1 {{ .Program }} $args --generate-bash-completion 2>/dev/null
+)'


### PR DESCRIPTION
## Summary
- Fish shell completions previously used urfave/cli's static `ToFishCompletion()`, which only generated completions for subcommands and flags — AWS profile names were never listed
- Replaced with dynamic fish completion templates that call `assumego --generate-bash-completion` at tab-completion time, matching the existing zsh behavior
- Separate completion files are now generated for both `assume` and `granted` commands

## Test plan
- [x] Run `granted completion --shell fish` and verify files are created in `~/.config/fish/completions/`
- [x] In fish shell, type `assume ` + tab and verify AWS profiles from `~/.aws/config` and `~/.aws/credentials` are listed
- [x] Verify `assume -` + tab still lists flags
- [x] Verify `granted ` + tab still lists subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)