### PR TITLE
fix: registry commands respect AWS_CONFIG_FILE

### DIFF
--- a/pkg/granted/registry/ini.go
+++ b/pkg/granted/registry/ini.go
@@ -4,21 +4,17 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/common-fate/clio"
+	"github.com/fwdcloudsec/granted/pkg/cfaws"
 	"gopkg.in/ini.v1"
 )
 
-// Find the ~/.aws/config absolute path based on OS.
+// getDefaultAWSConfigLocation returns the AWS config file path,
+// respecting the AWS_CONFIG_FILE environment variable per
+// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 func getDefaultAWSConfigLocation() (string, error) {
-	h, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	configPath := filepath.Join(h, ".aws", "config")
-	return configPath, nil
+	return cfaws.GetAWSConfigPath(), nil
 }
 
 // loadAWSConfigFile loads the `~/.aws/config` file, and creates it if it doesn't exist.

--- a/pkg/granted/registry/ini.go
+++ b/pkg/granted/registry/ini.go
@@ -10,19 +10,10 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-// getDefaultAWSConfigLocation returns the AWS config file path,
-// respecting the AWS_CONFIG_FILE environment variable per
-// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-func getDefaultAWSConfigLocation() (string, error) {
-	return cfaws.GetAWSConfigPath(), nil
-}
-
-// loadAWSConfigFile loads the `~/.aws/config` file, and creates it if it doesn't exist.
+// loadAWSConfigFile loads the AWS config file, and creates it if it doesn't exist.
+// It respects the AWS_CONFIG_FILE environment variable.
 func loadAWSConfigFile() (*ini.File, string, error) {
-	filepath, err := getDefaultAWSConfigLocation()
-	if err != nil {
-		return nil, "", err
-	}
+	filepath := cfaws.GetAWSConfigPath()
 
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
 		clio.Infof("created AWS config file: %s", filepath)

--- a/pkg/granted/registry/ini_test.go
+++ b/pkg/granted/registry/ini_test.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDefaultAWSConfigLocation(t *testing.T) {
+	tests := []struct {
+		name       string
+		envValue   string
+		wantCustom bool
+	}{
+		{
+			name:       "uses AWS_CONFIG_FILE when set",
+			envValue:   "/custom/path/config",
+			wantCustom: true,
+		},
+		{
+			name:       "falls back to default when not set",
+			envValue:   "",
+			wantCustom: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AWS_CONFIG_FILE", tt.envValue)
+
+			got, err := getDefaultAWSConfigLocation()
+			assert.NoError(t, err)
+			if tt.wantCustom {
+				assert.Equal(t, tt.envValue, got)
+			} else {
+				assert.Contains(t, got, ".aws/config")
+			}
+		})
+	}
+}
+
+func TestLoadAWSConfigFile_RespectsEnvVar(t *testing.T) {
+	// Create a temp dir with an AWS config file
+	tmpDir := t.TempDir()
+	customConfigPath := filepath.Join(tmpDir, "custom-aws-config")
+	err := os.WriteFile(customConfigPath, []byte("[profile test]\nregion = us-east-1\n"), 0600)
+	assert.NoError(t, err)
+
+	t.Setenv("AWS_CONFIG_FILE", customConfigPath)
+
+	cfg, path, err := loadAWSConfigFile()
+	assert.NoError(t, err)
+	assert.Equal(t, customConfigPath, path)
+	assert.NotNil(t, cfg)
+
+	// Verify it loaded the correct file
+	sec, err := cfg.GetSection("profile test")
+	assert.NoError(t, err)
+	assert.Equal(t, "us-east-1", sec.Key("region").String())
+}
+
+func TestLoadAWSConfigFile_DefaultPath(t *testing.T) {
+	t.Setenv("AWS_CONFIG_FILE", "")
+
+	_, path, err := loadAWSConfigFile()
+	assert.NoError(t, err)
+	assert.Contains(t, path, ".aws/config")
+}

--- a/pkg/granted/registry/ini_test.go
+++ b/pkg/granted/registry/ini_test.go
@@ -8,39 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetDefaultAWSConfigLocation(t *testing.T) {
-	tests := []struct {
-		name       string
-		envValue   string
-		wantCustom bool
-	}{
-		{
-			name:       "uses AWS_CONFIG_FILE when set",
-			envValue:   "/custom/path/config",
-			wantCustom: true,
-		},
-		{
-			name:       "falls back to default when not set",
-			envValue:   "",
-			wantCustom: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("AWS_CONFIG_FILE", tt.envValue)
-
-			got, err := getDefaultAWSConfigLocation()
-			assert.NoError(t, err)
-			if tt.wantCustom {
-				assert.Equal(t, tt.envValue, got)
-			} else {
-				assert.Contains(t, got, ".aws/config")
-			}
-		})
-	}
-}
-
 func TestLoadAWSConfigFile_RespectsEnvVar(t *testing.T) {
 	// Create a temp dir with an AWS config file
 	tmpDir := t.TempDir()
@@ -62,9 +29,15 @@ func TestLoadAWSConfigFile_RespectsEnvVar(t *testing.T) {
 }
 
 func TestLoadAWSConfigFile_DefaultPath(t *testing.T) {
+	// Sandbox HOME: loadAWSConfigFile auto-creates ~/.aws/config when missing,
+	// so without this it would touch the real user's home dir on a fresh machine.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
 	t.Setenv("AWS_CONFIG_FILE", "")
 
 	_, path, err := loadAWSConfigFile()
 	assert.NoError(t, err)
-	assert.Contains(t, path, ".aws/config")
+	// Exact match — a substring check would also pass for unrelated paths
+	// like "/foo/.aws/config-backup".
+	assert.Equal(t, filepath.Join(tmpHome, ".aws", "config"), path)
 }

--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -188,7 +188,7 @@ func FieldOptions(cfg any) map[string]Field {
 	configValue := reflect.ValueOf(cfg)
 
 	// Check if cfg is a pointer to a struct
-	if configType.Kind() == reflect.Ptr && configType.Elem().Kind() == reflect.Struct {
+	if configType.Kind() == reflect.Pointer && configType.Elem().Kind() == reflect.Struct {
 		configType = configType.Elem()
 		configValue = configValue.Elem()
 	} else if configType.Kind() != reflect.Struct {
@@ -212,7 +212,7 @@ func FieldOptions(cfg any) map[string]Field {
 			}
 
 			//subfield structs reflect as a pointer
-			if kind == reflect.Ptr {
+			if kind == reflect.Pointer {
 				// Dereference the pointer to get the underlying value
 				if !fieldValue.IsNil() {
 					fieldValue = fieldValue.Elem()


### PR DESCRIPTION
Fixes #926

Registry commands (`add`, `sync`, `remove`, `setup`) ignored `AWS_CONFIG_FILE` and always used `~/.aws/config`. This was fixed for `assume` in #229 but missed for registry.

The fix reuses `cfaws.GetAWSConfigPath()` — the same function already used by `assume`, `granted sso`, and `granted credentials` to resolve the config path.

Added tests for both custom and default paths.