### PR TITLE
fix: skip plaintext cache tokens with non-SSO scopes

### DIFF
--- a/pkg/cfaws/ssotoken.go
+++ b/pkg/cfaws/ssotoken.go
@@ -16,11 +16,12 @@ import (
 )
 
 type SSOPlainTextOut struct {
-	AccessToken    string `json:"accessToken"`
-	ExpiresAt      string `json:"expiresAt"`
-	SSOSessionName string `json:"ssoSessionName"`
-	StartUrl       string `json:"startUrl"`
-	Region         string `json:"region"`
+	AccessToken    string   `json:"accessToken"`
+	ExpiresAt      string   `json:"expiresAt"`
+	SSOSessionName string   `json:"ssoSessionName"`
+	StartUrl       string   `json:"startUrl"`
+	Region         string   `json:"region"`
+	Scopes         []string `json:"scopes,omitempty"`
 }
 
 // CreatePlainTextSSO is currently unused. In a future version of the Granted CLI,
@@ -182,14 +183,29 @@ func ReadPlaintextSsoCreds(startUrl string) (SSOPlainTextOut, error) {
 				if err != nil {
 					return SSOPlainTextOut{}, err
 				}
-				// check if the startUrl matches
-				if sso.StartUrl == startUrl {
+				// check if the startUrl matches and the token has appropriate scopes
+				if sso.StartUrl == startUrl && hasSSOScopes(sso.Scopes) {
 					return sso, nil
 				}
 			}
 		}
 	}
 	return SSOPlainTextOut{}, fmt.Errorf("no valid sso token found")
+}
+
+// hasSSOScopes returns true if the token has scopes that include SSO account
+// access, or if no scopes are specified (for backwards compatibility with
+// tokens that don't include scope metadata).
+func hasSSOScopes(scopes []string) bool {
+	if len(scopes) == 0 {
+		return true
+	}
+	for _, scope := range scopes {
+		if strings.HasPrefix(scope, "sso:") {
+			return true
+		}
+	}
+	return false
 }
 
 func GetValidSSOTokenFromPlaintextCache(startUrl string) *securestorage.SSOToken {


### PR DESCRIPTION
### What changed?

`GetValidSSOTokenFromPlaintextCache` now parses the `scopes` field of plaintext cache tokens and only accepts tokens that either have no scopes (backwards compatible) or include at least one `sso:*` scope.

### Why?

When an IDE extension (e.g. AWS Toolkit / Amazon Q for VS Code) is authenticated against the same SSO start URL, it writes a token to `~/.aws/sso/cache/` with scopes like `codewhisperer:completions`. `GetValidSSOTokenFromPlaintextCache` matched tokens by `startUrl` only, so it picked up this unrelated token, stored it to the keychain, and used it for `GetRoleCredentials`. AWS returned a 401 because the token lacks `sso:account:access`, and Granted did not fall through to the browser login flow.

### How did you test it?

- Had Amazon Q IDE extension authenticated (token in `~/.aws/sso/cache/` with only `codewhisperer:*` scopes)
- Cleared keychain tokens (`granted sso-tokens clear --all`)
- Ran `assume <profile>` — previously got 401, now correctly triggers browser login via device code flow
- Confirmed successful credential retrieval after browser authentication

### Potential risks

Low. Tokens with no scopes field are still accepted (backwards compatible). Only tokens that explicitly declare scopes and lack any `sso:*` scope are skipped. This covers any current or future non-SSO tools writing tokens to the shared cache.

### Is patch release candidate?

Yes — this is a bugfix for a broken login flow that affects anyone using Granted alongside AWS IDE extensions.

### Link to relevant issues

Fixes #940

Co-authored-by: Amazon Q