### PR TITLE
feat(assume): add --export-as option

### DIFF
--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -21,6 +21,7 @@ import (
 	"github.com/common-fate/clio"
 	"github.com/common-fate/clio/ansi"
 	"github.com/common-fate/clio/clierr"
+	"github.com/fatih/color"
 	"github.com/fwdcloudsec/granted/pkg/assumeprint"
 	"github.com/fwdcloudsec/granted/pkg/browser"
 	"github.com/fwdcloudsec/granted/pkg/cfaws"
@@ -30,7 +31,6 @@ import (
 	"github.com/fwdcloudsec/granted/pkg/launcher"
 	"github.com/fwdcloudsec/granted/pkg/testable"
 	cfflags "github.com/fwdcloudsec/granted/pkg/urfav_overrides"
-	"github.com/fatih/color"
 	"github.com/hako/durafmt"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/ini.v1"
@@ -465,19 +465,29 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Success("Exported credentials to .env file successfully")
 		}
 
-		if assumeFlags.Bool("export") || cfg.ExportCredsToAWS {
-			err = cfaws.ExportCredsToProfile(profile.Name, creds)
+		exportAsProfileName := strings.TrimSpace(assumeFlags.String("export-as"))
+		if assumeFlags.Bool("export") || cfg.ExportCredsToAWS || exportAsProfileName != "" {
+			exportProfileName := profile.Name
+			applyExportSuffix := true
+			if exportAsProfileName != "" {
+				exportProfileName = exportAsProfileName
+				applyExportSuffix = false
+			}
+
+			err = cfaws.ExportCredsToProfileWithOptions(exportProfileName, creds, applyExportSuffix)
 			if err != nil {
 				return err
 			}
-			var profileName string
-			if cfg.ExportCredentialSuffix == nil {
-				profileName = profile.Name
-				clio.Warn("No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run `granted settings export-suffix set` to set one. Set to empty string to supress this warning")
-			} else if *cfg.ExportCredentialSuffix != "" {
-				profileName = profile.Name + "-" + *cfg.ExportCredentialSuffix
-			} else {
-				profileName = profile.Name
+			profileName := exportProfileName
+			if applyExportSuffix {
+				if cfg.ExportCredentialSuffix == nil {
+					profileName = profile.Name
+					clio.Warn("No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run `granted settings export-suffix set` to set one. Set to empty string to supress this warning")
+				} else if *cfg.ExportCredentialSuffix != "" {
+					profileName = profile.Name + "-" + *cfg.ExportCredentialSuffix
+				} else {
+					profileName = profile.Name
+				}
 			}
 
 			credentialsFilePath := cfaws.GetAWSCredentialsPath()

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -21,6 +21,7 @@ import (
 	"github.com/common-fate/clio"
 	"github.com/common-fate/clio/ansi"
 	"github.com/common-fate/clio/clierr"
+	"github.com/fatih/color"
 	"github.com/fwdcloudsec/granted/pkg/assumeprint"
 	"github.com/fwdcloudsec/granted/pkg/browser"
 	"github.com/fwdcloudsec/granted/pkg/cfaws"
@@ -30,7 +31,6 @@ import (
 	"github.com/fwdcloudsec/granted/pkg/launcher"
 	"github.com/fwdcloudsec/granted/pkg/testable"
 	cfflags "github.com/fwdcloudsec/granted/pkg/urfav_overrides"
-	"github.com/fatih/color"
 	"github.com/hako/durafmt"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/ini.v1"
@@ -431,19 +431,29 @@ func AssumeCommand(c *cli.Context) error {
 			clio.Success("Exported credentials to .env file successfully")
 		}
 
-		if assumeFlags.Bool("export") || cfg.ExportCredsToAWS {
-			err = cfaws.ExportCredsToProfile(profile.Name, creds)
+		exportAsProfileName := strings.TrimSpace(assumeFlags.String("export-as"))
+		if assumeFlags.Bool("export") || cfg.ExportCredsToAWS || exportAsProfileName != "" {
+			exportProfileName := profile.Name
+			applyExportSuffix := true
+			if exportAsProfileName != "" {
+				exportProfileName = exportAsProfileName
+				applyExportSuffix = false
+			}
+
+			err = cfaws.ExportCredsToProfileWithOptions(exportProfileName, creds, applyExportSuffix)
 			if err != nil {
 				return err
 			}
-			var profileName string
-			if cfg.ExportCredentialSuffix == nil {
-				profileName = profile.Name
-				clio.Warn("No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run `granted settings export-suffix set` to set one. Set to empty string to supress this warning")
-			} else if *cfg.ExportCredentialSuffix != "" {
-				profileName = profile.Name + "-" + *cfg.ExportCredentialSuffix
-			} else {
-				profileName = profile.Name
+			profileName := exportProfileName
+			if applyExportSuffix {
+				if cfg.ExportCredentialSuffix == nil {
+					profileName = profile.Name
+					clio.Warn("No credential suffix found. This can cause issues with using exported credentials if conflicting profiles exist. Run `granted settings export-suffix set` to set one. Set to empty string to supress this warning")
+				} else if *cfg.ExportCredentialSuffix != "" {
+					profileName = profile.Name + "-" + *cfg.ExportCredentialSuffix
+				} else {
+					profileName = profile.Name
+				}
 			}
 
 			credentialsFilePath := cfaws.GetAWSCredentialsPath()

--- a/pkg/assume/assume.go
+++ b/pkg/assume/assume.go
@@ -440,7 +440,7 @@ func AssumeCommand(c *cli.Context) error {
 				applyExportSuffix = false
 			}
 
-			err = cfaws.ExportCredsToProfileWithOptions(exportProfileName, creds, applyExportSuffix)
+			err = cfaws.ExportCredsToProfile(exportProfileName, creds, applyExportSuffix)
 			if err != nil {
 				return err
 			}

--- a/pkg/assume/entrypoint.go
+++ b/pkg/assume/entrypoint.go
@@ -27,6 +27,7 @@ func GlobalFlags() []cli.Flag {
 		&cli.BoolFlag{Name: "terminal", Aliases: []string{"t"}, Usage: "Use this with '-c' to open a console session and export credentials into the terminal at the same time."},
 		&cli.BoolFlag{Name: "env", Aliases: []string{"e"}, Usage: "Export credentials to a .env file"},
 		&cli.BoolFlag{Name: "export", Aliases: []string{"ex"}, Usage: "Export credentials to a ~/.aws/credentials file"},
+		&cli.StringFlag{Name: "export-as", Usage: "Export credentials to ~/.aws/credentials using a custom profile name"},
 		&cli.BoolFlag{Name: "export-sso-token", Aliases: []string{"es"}, Usage: "Export sso token to ~/.aws/sso/cache"},
 		&cli.BoolFlag{Name: "unset", Aliases: []string{"un"}, Usage: "Unset all environment variables configured by Assume"},
 		&cli.BoolFlag{Name: "url", Aliases: []string{"u"}, Usage: "Get an active console session url"},

--- a/pkg/cfaws/cred_exporter.go
+++ b/pkg/cfaws/cred_exporter.go
@@ -13,6 +13,11 @@ import (
 
 // ExportCredsToProfile will write assumed credentials to ~/.aws/credentials with a specified profile name header
 func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
+	return ExportCredsToProfileWithOptions(profileName, creds, true)
+}
+
+// ExportCredsToProfileWithOptions will write assumed credentials to ~/.aws/credentials with additional export options
+func ExportCredsToProfileWithOptions(profileName string, creds aws.Credentials, applySuffix bool) error {
 	// fetch the parsed cred file
 	credPath := GetAWSCredentialsPath()
 
@@ -40,13 +45,15 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 		return err
 	}
 
-	cfg, err := gconfig.Load()
-	if err != nil {
-		return err
-	}
+	if applySuffix {
+		cfg, err := gconfig.Load()
+		if err != nil {
+			return err
+		}
 
-	if cfg.ExportCredentialSuffix != nil && *cfg.ExportCredentialSuffix!= "" {
-		profileName = profileName + "-" + *cfg.ExportCredentialSuffix
+		if cfg.ExportCredentialSuffix != nil && *cfg.ExportCredentialSuffix != "" {
+			profileName = profileName + "-" + *cfg.ExportCredentialSuffix
+		}
 	}
 
 	credentialsFile.DeleteSection(profileName)

--- a/pkg/cfaws/cred_exporter.go
+++ b/pkg/cfaws/cred_exporter.go
@@ -12,12 +12,7 @@ import (
 )
 
 // ExportCredsToProfile will write assumed credentials to ~/.aws/credentials with a specified profile name header
-func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
-	return ExportCredsToProfileWithOptions(profileName, creds, true)
-}
-
-// ExportCredsToProfileWithOptions will write assumed credentials to ~/.aws/credentials with additional export options
-func ExportCredsToProfileWithOptions(profileName string, creds aws.Credentials, applySuffix bool) error {
+func ExportCredsToProfile(profileName string, creds aws.Credentials, applySuffix bool) error {
 	// fetch the parsed cred file
 	credPath := GetAWSCredentialsPath()
 


### PR DESCRIPTION
## Description
This PR implements the feature requested in #821 by adding support for exporting credentials to `~/.aws/credentials` under a custom profile name.

### What changed
- Added a new `assume` flag: `--export-as`
  - Example: `assume <source-profile> --export-as <new-profile-name>`
 
- Updated export flow to:
  - Trigger credential export when `--export-as` is provided (even without `--export`)
  - Use the provided custom profile name as-is
 
- Extended credential export implementation with:
  - `ExportCredsToProfileWithOptions(profileName, creds, applySuffix bool)`
 
### Behavior details
- Existing behavior is unchanged for `--export`:
  - `ExportCredentialSuffix` is still applied when configured.
- New behavior for `--export-as`:
  - `ExportCredentialSuffix` is intentionally **not** applied.
  - The destination profile name is exactly the value passed to `--export-as`.


Closes #821.