### PR TITLE
fix: add Zen.app as macOS detection path for Zen browser

### DIFF
--- a/pkg/browser/browsers.go
+++ b/pkg/browser/browsers.go
@@ -66,7 +66,7 @@ var SafariPathMac = []string{"/Applications/Safari.app/Contents/MacOS/Safari"}
 
 var ArcPathMac = []string{"/Applications/Arc.app/Contents/MacOS/Arc"}
 
-var ZenPathMac = []string{"/Applications/Zen Browser.app/Contents/MacOS/zen"}
+var ZenPathMac = []string{"/Applications/Zen.app/Contents/MacOS/zen", "/Applications/Zen Browser.app/Contents/MacOS/zen"}
 var ZenPathLinux = []string{`/usr/bin/zen-browser`, `/opt/zen-browser/zen`}
 var ZenPathWindows = []string{`\Program Files\Zen Browser\zen.exe`}
 


### PR DESCRIPTION
Current Zen Browser releases on macOS install to `/Applications/Zen.app`, but the existing detection path only checks `/Applications/Zen Browser.app`. This causes granted browser set to never auto-detect the installation and always fall back to prompting the user for a manual path.

This PR adds `/Applications/Zen.app/Contents/MacOS/zen` (the new Zen Browser path) as the first candidate in ZenPathMac, while keeping the old path as a fallback for users on older installations.

Changes

- pkg/browser/browsers.go: add `Zen.app` as the primary macOS path for Zen Browser detection

Testing

Verified on macOS with Zen Browser installed at `/Applications/Zen.app` — `granted browser set` now auto-detects the installation without prompting for a manual path.