### PR TITLE
docs(README.md): Change Slack link to fwd:cloudsec forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
 <a align="center" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fgranted.dev&text=I%20just%20used%20Granted%20to%20log%20in%20to%20all%20my%20AWS%20accounts%20at%20once%21"><img src="https://img.shields.io/twitter/url/https/github.com/tterb/hyde.svg?style=social" alt="tweet" /></a>
-<a href="https://join.slack.com/t/commonfatecommunity/shared_invite/zt-q4m96ypu-_gYlRWD3k5rIsaSsqP7QMg"><img src="https://img.shields.io/badge/slack-commonfate-1F72FE.svg?logo=slack" alt="slack" /></a>
+<a href="https://fwdcloudsec.org/forum/"><img src="https://img.shields.io/badge/slack-fwd:cloudsec-1F72FE.svg?logo=slack" alt="slack" /></a>
 </p>
 
 <p align="center">
@@ -42,7 +42,7 @@ Get started by [reading our documentation](https://docs.commonfate.io/granted/ge
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute. We welcome all contributors - [join our Slack](https://join.slack.com/t/commonfatecommunity/shared_invite/zt-q4m96ypu-_gYlRWD3k5rIsaSsqP7QMg) to discuss the project!
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute. We welcome all contributors - [join our Slack](https://fwdcloudsec.org/forum/) to discuss the project!
 
 ## Security
 


### PR DESCRIPTION
Updated Slack link in README to point to the fwd:cloudsec forum (https://fwdcloudsec.org/forum/)