### PR TITLE
Add amplify to service map

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -6,6 +6,7 @@ var ServiceMap = map[string]string{
 	"":                  "console",
 	"acm":               "acm",
 	"aos":               "aos",
+	"amplify":           "amplify",
 	"apigateway":        "apigateway",
 	"apigw":             "apigateway",
 	"appsync":           "appsync",


### PR DESCRIPTION
Duplicate of #883 — recreated from a clean base off current main to avoid the rebase conflicts.
Same one-line change to `service_map.go`.