### PR TITLE
add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+# Maintainers
+
+- [Overview](#overview)
+- [Current Maintainers](#current-maintainers)
+- [Emeritus](#emeritus)
+
+## Overview
+
+This document contains a list of maintainers in this repo. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+
+We are in the process of deciding on the full list of maintainers for this project.
+
+## Current Maintainers
+
+| Maintainer | GitHub ID                                     | Affiliation |
+| ---------- | ---------------------------------------------- | ----------- |
+| Jack Meyer | [meyerjrr](https://github.com/meyerjrr)        | Common Fate |
+
+## Emeritus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,8 +8,6 @@
 
 This document contains a list of maintainers in this repo. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
 
-We are in the process of deciding on the full list of maintainers for this project.
-
 ## Current Maintainers
 
 | Maintainer    | GitHub ID                                              | Affiliation  |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,5 +15,6 @@ We are in the process of deciding on the full list of maintainers for this proje
 | Maintainer | GitHub ID                                     | Affiliation |
 | ---------- | ---------------------------------------------- | ----------- |
 | Jack Meyer | [meyerjrr](https://github.com/meyerjrr)        | Common Fate |
+| Samuel Burgos | [sbldevnet](https://github.com/sbldevnet) | Independent  |
 
 ## Emeritus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,9 +12,12 @@ We are in the process of deciding on the full list of maintainers for this proje
 
 ## Current Maintainers
 
-| Maintainer | GitHub ID                                     | Affiliation |
-| ---------- | ---------------------------------------------- | ----------- |
-| Jack Meyer | [meyerjrr](https://github.com/meyerjrr)        | Common Fate |
-| Samuel Burgos | [sbldevnet](https://github.com/sbldevnet) | Independent  |
+| Maintainer    | GitHub ID                                              | Affiliation  |
+| ------------- | ------------------------------------------------------ | ------------ |
+| Jack Meyer    | [meyerjrr](https://github.com/meyerjrr)                | Common Fate  |
+| Samuel Burgos | [sbldevnet](https://github.com/sbldevnet)              | Independent  |
+| Josh Wilkes   | [JoshuaWilkes](https://github.com/JoshuaWilkes)        | Common Fate  |
+| Chris Norman  | [chrnorm](https://github.com/chrnorm)                  | Common Fate  |
+| Chris Farris  | [jchrisfarris](https://github.com/jchrisfarris)        | fwd:cloudsec |
 
 ## Emeritus

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Get started by [reading our documentation](https://docs.granted.dev/getting-star
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute. We welcome all contributors - [join our Slack](https://fwdcloudsec.org/forum/) to discuss the project!
 
+See [MAINTAINERS.md](./MAINTAINERS.md) for the list of project maintainers.
+
 ## Security
 
 See [SECURITY.md](./SECURITY.md) for security information. You can view our full security documentation on the [Granted website](https://docs.granted.dev/security).


### PR DESCRIPTION
For some added clarity on maintainers of the project I am creating a `MAINTAINERS.md` to keep track of existing and prior maintainers. We are currently in the process of recalibrating who is still involved so will update this list as we lock things down.