### PR TITLE
fix: sort the settings and token menus

### DIFF
--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -43,7 +43,6 @@ var SetConfigCommand = cli.Command{
 		for k := range fieldMap {
 			fields = append(fields, k)
 		}
-		// map iteration is randomised, so sort for a stable menu order
 		sort.Strings(fields)
 
 		var selectedFieldName = c.String("setting")

--- a/pkg/granted/settings/set.go
+++ b/pkg/granted/settings/set.go
@@ -3,6 +3,7 @@ package settings
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -42,6 +43,8 @@ var SetConfigCommand = cli.Command{
 		for k := range fieldMap {
 			fields = append(fields, k)
 		}
+		// map iteration is randomised, so sort for a stable menu order
+		sort.Strings(fields)
 
 		var selectedFieldName = c.String("setting")
 		if selectedFieldName == "" {

--- a/pkg/granted/tokens.go
+++ b/pkg/granted/tokens.go
@@ -227,7 +227,6 @@ var ClearSSOTokensCommand = cli.Command{
 				tokenList = append(tokenList, stringKey)
 				selectionsMap[stringKey] = k
 			}
-			// map iteration is randomised, so sort for a stable menu order
 			sort.Strings(tokenList)
 			withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 			in := survey.Select{

--- a/pkg/granted/tokens.go
+++ b/pkg/granted/tokens.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -226,6 +227,8 @@ var ClearSSOTokensCommand = cli.Command{
 				tokenList = append(tokenList, stringKey)
 				selectionsMap[stringKey] = k
 			}
+			// map iteration is randomised, so sort for a stable menu order
+			sort.Strings(tokenList)
 			withStdio := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
 			in := survey.Select{
 				Message: "Select a token to remove from keyring",


### PR DESCRIPTION
`granted settings set` and `granted sso-tokens clear` both build their menus by
ranging over a map, so Go's randomised iteration order lists them differently on
every run:

```
run 1: AccessRequestURL, ProfileRegistry.PrefixAllProfiles, DefaultBrowser, ExportCredsToAWS
run 2: CustomBrowserPath, Ordering, AccessRequestURL, CommonFateDefaultSSORegion
run 3: Ordering, AccessRequestURL, CommonFateDefaultSSOStartURL, CustomSSOBrowserPath
```

Sorting makes them predictable enough to build muscle memory against. Nothing
downstream depends on the order — in both cases the selection is looked up by
name after the prompt returns.

Pre-existing rather than a regression: survey renders options in the order it is
handed them, so `main` behaves the same way today. Spotted while working on #956
and kept separate, since it is unrelated to that change.
