### PR TITLE
feat(sso): support full credential process paths

### DIFF
--- a/pkg/cfaws/cred_exporter.go
+++ b/pkg/cfaws/cred_exporter.go
@@ -13,6 +13,12 @@ import (
 
 // ExportCredsToProfile will write assumed credentials to ~/.aws/credentials with a specified profile name header
 func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
+	return ExportCredsToProfileWithOptions(profileName, creds, true)
+}
+
+// ExportCredsToProfileWithOptions writes assumed credentials to a profile and
+// optionally applies the configured export credential suffix.
+func ExportCredsToProfileWithOptions(profileName string, creds aws.Credentials, applySuffix bool) error {
 	// fetch the parsed cred file
 	credPath := GetAWSCredentialsPath()
 
@@ -45,7 +51,7 @@ func ExportCredsToProfile(profileName string, creds aws.Credentials) error {
 		return err
 	}
 
-	if cfg.ExportCredentialSuffix != nil && *cfg.ExportCredentialSuffix!= "" {
+	if applySuffix && cfg.ExportCredentialSuffix != nil && *cfg.ExportCredentialSuffix != "" {
 		profileName = profileName + "-" + *cfg.ExportCredentialSuffix
 	}
 

--- a/pkg/cfaws/cred_exporter_test.go
+++ b/pkg/cfaws/cred_exporter_test.go
@@ -1,0 +1,85 @@
+package cfaws
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	grantedconfig "github.com/fwdcloudsec/granted/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/ini.v1"
+)
+
+func TestExportCredsToProfileWithOptions_AppliesSuffix(t *testing.T) {
+	tests := []struct {
+		name              string
+		sourceProfileName string
+		applySuffix       bool
+		expectedSection   string
+		unexpectedSection string
+	}{
+		{
+			name:              "applies configured suffix",
+			sourceProfileName: "source-profile",
+			applySuffix:       true,
+			expectedSection:   "source-profile-team",
+			unexpectedSection: "source-profile",
+		},
+		{
+			name:              "skips suffix with custom export name",
+			sourceProfileName: "renamed-profile",
+			applySuffix:       false,
+			expectedSection:   "renamed-profile",
+			unexpectedSection: "renamed-profile-team",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpHome := t.TempDir()
+			tmpCredsPath := filepath.Join(tmpHome, "aws-credentials")
+			t.Setenv("HOME", tmpHome)
+			t.Setenv("AWS_SHARED_CREDENTIALS_FILE", tmpCredsPath)
+
+			suffix := "team"
+			writeGrantedConfigForTest(t, &suffix)
+
+			err := ExportCredsToProfileWithOptions(tt.sourceProfileName, testCreds(), tt.applySuffix)
+			assert.NoError(t, err)
+
+			credentialsFile, err := ini.Load(tmpCredsPath)
+			assert.NoError(t, err)
+
+			section, err := credentialsFile.GetSection(tt.expectedSection)
+			assert.NoError(t, err)
+			assert.Equal(t, "AKIA_TEST", section.Key("aws_access_key_id").String())
+			assert.Equal(t, "secret_test", section.Key("aws_secret_access_key").String())
+			assert.Equal(t, "token_test", section.Key("aws_session_token").String())
+
+			_, err = credentialsFile.GetSection(tt.unexpectedSection)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func writeGrantedConfigForTest(t *testing.T, suffix *string) {
+	t.Helper()
+
+	grantedFolder := filepath.Join(os.Getenv("HOME"), ".dgranted")
+	err := os.MkdirAll(grantedFolder, 0700)
+	assert.NoError(t, err)
+
+	cfg := grantedconfig.NewDefaultConfig()
+	cfg.ExportCredentialSuffix = suffix
+	err = cfg.Save()
+	assert.NoError(t, err)
+}
+
+func testCreds() aws.Credentials {
+	return aws.Credentials{
+		AccessKeyID:     "AKIA_TEST",
+		SecretAccessKey: "secret_test",
+		SessionToken:    "token_test",
+	}
+}

--- a/pkg/cfaws/granted_config.go
+++ b/pkg/cfaws/granted_config.go
@@ -128,8 +128,18 @@ func hasGrantedSSOPrefix(rawConfig *ini.Section) bool {
 // also check whether the provided flag to 'granted credential-process --profile pname'
 // matches the AWS config profile name. If it doesn't then return an err
 // as the user will certainly run into unexpected behaviour.
+//
+// The credential_process value may reference the granted/dgranted binary
+// either as a bare command (relying on $PATH resolution) or via a relative
+// or absolute path (e.g. '/home/user/.local/bin/granted'). This allows users
+// to write the full path to the binary, which is useful in environments
+// where the process invoking the AWS SDK doesn't share the same $PATH as
+// the interactive shell (IDEs, GUI apps, containers, cron jobs, etc.).
+// Only the last path segment (the binary name, ignoring any directory
+// prefix and an optional Windows '.exe' suffix) is checked against
+// 'granted'/'dgranted'.
 func validateCredentialProcess(arg string, awsProfileName string) error {
-	regex := regexp.MustCompile(`^(\s+)?(dgranted|granted)\s+credential-process.*--profile\s+(?P<PName>([^\s]+))`)
+	regex := regexp.MustCompile(`^(\s+)?(?:\S*[\\/])?(dgranted|granted)(\.exe)?\s+credential-process.*--profile\s+(?P<PName>([^\s]+))`)
 
 	if regex.MatchString(arg) {
 		matches := regex.FindStringSubmatch(arg)

--- a/pkg/cfaws/granted_config_test.go
+++ b/pkg/cfaws/granted_config_test.go
@@ -28,16 +28,98 @@ func TestValidateCredentialProcess(t *testing.T) {
 			profileName: "apple",
 			wantErr:     "unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'",
 		},
+		{
+			name:        "valid argument using dgranted bare command",
+			arg:         "dgranted credential-process --profile develop",
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument with relative path",
+			arg:         "./granted credential-process --profile develop",
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument with relative path in subdirectory",
+			arg:         "bin/dgranted credential-process --profile develop",
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument with absolute unix path",
+			arg:         "/home/user/.local/bin/granted credential-process --profile develop",
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument with absolute unix path and profile containing a slash",
+			arg:         "/home/user/.local/bin/granted credential-process --profile my-account/MyRole",
+			profileName: "my-account/MyRole",
+		},
+		{
+			name:        "valid argument with absolute unix path to dgranted",
+			arg:         "/home/user/.local/bin/dgranted credential-process --profile develop",
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument with windows path and .exe suffix",
+			arg:         `C:\Users\foo\bin\granted.exe credential-process --profile develop`,
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument with windows path and .exe suffix to dgranted",
+			arg:         `C:\Users\foo\bin\dgranted.exe credential-process --profile develop`,
+			profileName: "develop",
+		},
+		{
+			name:        "valid argument with bare .exe suffix",
+			arg:         "granted.exe credential-process --profile develop",
+			profileName: "develop",
+		},
+		{
+			name:        "full path with mismatched profile name still detected",
+			arg:         "/home/user/.local/bin/granted credential-process --profile abc",
+			profileName: "develop",
+			wantErr:     "unmatched profile names. The profile name 'abc' provided to 'granted credential-process' does not match AWS profile name 'develop'",
+		},
+		{
+			name:        "rejects an unrelated binary invoked via an absolute path",
+			arg:         "/usr/local/bin/aws-vault credential-process --profile develop",
+			profileName: "develop",
+			wantErr:     "unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'",
+		},
+		{
+			name:        "rejects a binary that merely starts with 'granted'",
+			arg:         "/usr/local/bin/granted-wrapper credential-process --profile develop",
+			profileName: "develop",
+			wantErr:     "unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'",
+		},
+		{
+			name:        "rejects a bare command that merely starts with 'granted'",
+			arg:         "grantedx credential-process --profile develop",
+			profileName: "develop",
+			wantErr:     "unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'",
+		},
+		{
+			name:        "missing profile name",
+			arg:         "granted credential-process",
+			profileName: "develop",
+			wantErr:     "unable to parse 'credential_process'. Looks like your credential_process isn't configured correctly. \n You need to add 'granted credential-process --profile <profile-name>'",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			err := validateCredentialProcess(tt.arg, tt.profileName)
-			if err != nil {
-				if err.Error() != tt.wantErr {
+			if tt.wantErr == "" {
+				if err != nil {
 					t.Fatal(err)
 				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+			if err.Error() != tt.wantErr {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/pkg/granted/sso.go
+++ b/pkg/granted/sso.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -56,6 +57,7 @@ var GenerateCommand = cli.Command{
 		&cli.StringFlag{Name: "default-region", Usage: "Set the 'region' key on generated profiles (can differ from the SSO region)"},
 		&cli.StringSliceFlag{Name: "source", Usage: "The sources to load AWS profiles from (valid values are: 'aws-sso')", Value: cli.NewStringSlice("aws-sso")},
 		&cli.BoolFlag{Name: "no-credential-process", Usage: "Generate profiles without the Granted credential-process integration"},
+		&cli.BoolFlag{Name: "credential-process-full-path", Usage: "Use the full path to the current granted binary in generated credential_process entries, instead of relying on $PATH"},
 		&cli.StringFlag{Name: "profile-template", Usage: "Specify profile name template", Value: awsconfigfile.DefaultProfileNameTemplate},
 		&cli.StringFlag{Name: "sso-browser-profile", Usage: "Use a pre-existing profile in your browser for SSO login", EnvVars: []string{"GRANTED_SSO_BROWSER_PROFILE"}},
 		&cli.BoolFlag{Name: "use-device-code", Usage: "Force device code flow even if authorization code with PKCE is enabled"},
@@ -102,6 +104,14 @@ var GenerateCommand = cli.Command{
 			return err
 		}
 
+		var binaryPath string
+		if c.Bool("credential-process-full-path") {
+			binaryPath, err = resolveCredentialProcessBinaryPath()
+			if err != nil {
+				return err
+			}
+		}
+
 		g := awsconfigfile.Generator{
 			Config:              ini.Empty(),
 			ProfileNameTemplate: profileNameTemplate,
@@ -124,6 +134,9 @@ var GenerateCommand = cli.Command{
 		err = g.Generate(ctx)
 		if err != nil {
 			return err
+		}
+		if binaryPath != "" {
+			applyCredentialProcessBinaryPath(g.Config, binaryPath)
 		}
 
 		_, err = g.Config.WriteTo(os.Stdout)
@@ -149,6 +162,7 @@ var PopulateCommand = cli.Command{
 		&cli.BoolFlag{Name: "prune", Usage: "Remove any generated profiles with the 'common_fate_generated_from' key which no longer exist"},
 		&cli.StringFlag{Name: "profile-template", Usage: "Specify profile name template", Value: awsconfigfile.DefaultProfileNameTemplate},
 		&cli.BoolFlag{Name: "no-credential-process", Usage: "Generate profiles without the Granted credential-process integration"},
+		&cli.BoolFlag{Name: "credential-process-full-path", Usage: "Use the full path to the current granted binary in generated credential_process entries, instead of relying on $PATH"},
 		&cli.StringFlag{Name: "sso-browser-profile", Usage: "Use a pre-existing profile in your browser for SSO login", EnvVars: []string{"GRANTED_SSO_BROWSER_PROFILE"}},
 		&cli.BoolFlag{Name: "use-device-code", Usage: "Force device code flow even if authorization code with PKCE is enabled"},
 	},
@@ -224,6 +238,14 @@ var PopulateCommand = cli.Command{
 			pruneStartURLs = []string{startURL}
 		}
 
+		var binaryPath string
+		if c.Bool("credential-process-full-path") {
+			binaryPath, err = resolveCredentialProcessBinaryPath()
+			if err != nil {
+				return err
+			}
+		}
+
 		g := awsconfigfile.Generator{
 			Config:              config,
 			ProfileNameTemplate: profileNameTemplate,
@@ -246,6 +268,9 @@ var PopulateCommand = cli.Command{
 		err = g.Generate(ctx)
 		if err != nil {
 			return err
+		}
+		if binaryPath != "" {
+			applyCredentialProcessBinaryPath(config, binaryPath)
 		}
 
 		err = config.SaveTo(configFilename)
@@ -535,4 +560,48 @@ func resolveDefaultRegion(flagValue, configValue string) (string, error) {
 		return "", fmt.Errorf("couldn't parse default-region %s: %w", region, err)
 	}
 	return expanded, nil
+}
+
+// resolveCredentialProcessBinaryPath resolves the full path to the currently
+// running granted binary, for use in generated credential_process entries
+// (see the --credential-process-full-path flag).
+//
+// This is useful in environments where the process invoking the AWS SDK
+// doesn't have the same $PATH as the interactive shell (IDEs, GUI apps,
+// containers, cron jobs, etc.), since a bare 'granted' command would
+// otherwise fail to be found.
+//
+// We deliberately do not resolve symlinks (e.g. via filepath.EvalSymlinks)
+// here, so that a stable symlink path (such as the shims created by tools
+// like asdf or mise) keeps working after the underlying granted binary is
+// upgraded.
+func resolveCredentialProcessBinaryPath() (string, error) {
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve the full path to the current granted binary: %w", err)
+	}
+	return binaryPath, nil
+}
+
+func applyCredentialProcessBinaryPath(config *ini.File, binaryPath string) {
+	const generatedFrom = "common_fate_generated_from"
+	const credentialProcess = "credential_process"
+	const defaultCommand = "granted credential-process"
+
+	for _, section := range config.Sections() {
+		generatedFromKey, err := section.GetKey(generatedFrom)
+		if err != nil || generatedFromKey.String() != "aws-sso" {
+			continue
+		}
+
+		key, err := section.GetKey(credentialProcess)
+		if err != nil {
+			continue
+		}
+
+		remainder, ok := strings.CutPrefix(key.String(), defaultCommand)
+		if ok {
+			key.SetValue(binaryPath + " credential-process" + remainder)
+		}
+	}
 }

--- a/pkg/granted/sso_test.go
+++ b/pkg/granted/sso_test.go
@@ -1,6 +1,12 @@
 package granted
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/ini.v1"
+)
 
 func TestResolveDefaultRegion(t *testing.T) {
 	tests := []struct {
@@ -58,6 +64,77 @@ func TestResolveDefaultRegion(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("resolveDefaultRegion(%q, %q) = %q, want %q", tt.flagValue, tt.configValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCredentialProcessBinaryPath(t *testing.T) {
+	got, err := resolveCredentialProcessBinaryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got == "" {
+		t.Fatal("expected a non-empty binary path")
+	}
+
+	if !filepath.IsAbs(got) {
+		t.Fatalf("expected an absolute path, got %q", got)
+	}
+
+	want, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got != want {
+		t.Fatalf("resolveCredentialProcessBinaryPath() = %q, want %q", got, want)
+	}
+}
+
+func TestApplyCredentialProcessBinaryPath(t *testing.T) {
+	config, err := ini.Load([]byte(`
+[profile generated]
+common_fate_generated_from = aws-sso
+credential_process = granted credential-process --profile generated
+
+[profile regular]
+credential_process = granted credential-process --profile regular
+
+[profile other-generator]
+common_fate_generated_from = custom
+credential_process = granted credential-process --profile other-generator
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applyCredentialProcessBinaryPath(config, "/usr/local/bin/granted")
+
+	tests := []struct {
+		section string
+		want    string
+	}{
+		{
+			section: "profile generated",
+			want:    "/usr/local/bin/granted credential-process --profile generated",
+		},
+		{
+			section: "profile regular",
+			want:    "granted credential-process --profile regular",
+		},
+		{
+			section: "profile other-generator",
+			want:    "granted credential-process --profile other-generator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.section, func(t *testing.T) {
+			got := config.Section(tt.section).Key("credential_process").String()
+			if got != tt.want {
+				t.Fatalf("credential_process = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Support full binary paths in generated credential processes

## Summary

- Add a `--credential-process-full-path` option to `granted sso generate` and `granted sso populate`.
- Use the absolute path of the running Granted binary in generated AWS SSO `credential_process` entries when the option is enabled.
- Accept relative paths, absolute paths, Windows paths, and `.exe` suffixes when validating Granted credential processes.
- Allow credential exports to opt out of the configured profile suffix while preserving the existing default behavior.

## Motivation

Generated AWS profiles currently invoke `granted` by name and rely on the caller's `PATH`. This can fail when an AWS SDK is launched by an IDE, GUI application, container, or scheduled job whose environment differs from the user's interactive shell.

The new option generates entries such as:

```ini
credential_process = /usr/local/bin/granted credential-process --profile example/Developer
```

This allows the AWS SDK to invoke the same Granted binary directly without relying on `PATH` resolution.

## Behavior

The feature is opt-in. Without `--credential-process-full-path`, generated profiles continue to use:

```ini
credential_process = granted credential-process --profile example/Developer
```

When enabled, only profiles generated from the AWS SSO source are updated. Existing regular profiles and profiles created by other generators are left unchanged. Symlinks are intentionally not resolved so stable shim paths from tools such as asdf or mise remain valid after upgrades.

Credential process validation now recognizes `granted` and `dgranted` when invoked through Unix or Windows paths, including `.exe` filenames, while continuing to reject unrelated binaries and mismatched profile names.

## Testing

- Added tests for absolute, relative, and Windows credential process paths.
- Added tests for invalid binary names and mismatched profiles.
- Added tests for resolving and applying the current executable path only to generated AWS SSO profiles.
- Added tests for credential export suffix handling.
- Ran `go test ./...`.
